### PR TITLE
Plotmanager adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 compile:
 	rm -rf ./build
 	truffle compile
+	node scripts/checkContractSize.js
 
 validate:
 	npm run solium
@@ -10,7 +11,11 @@ validate:
 
 test:
 	truffle compile
+	node scripts/checkContractSize.js
 	npm test
+
+check-size:
+	node scripts/checkContractSize.js
 
 deploy-test:
 	truffle deploy --network test

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -607,8 +607,7 @@ contract PlotManager is Initializable, Ownable {
   }
 
   function claimValidatorReward(
-    bytes32 _aId,
-    Currency _currency
+    bytes32 _aId
   )
     external 
     onlyValidatorOfApplication(_aId)
@@ -622,15 +621,14 @@ contract PlotManager is Initializable, Ownable {
       "Application status should be ether APPROVED or DISASSEMBLED_BY_VALIDATOR");
 
     require(reward > 0, "Reward is 0");
-    require(a.currency == _currency, "Reward currency doesn't match");
     require(a.roleRewardPaidOut[senderRole] == false, "Reward is already paid");
     validators.ensureValidatorActive(msg.sender);
 
     a.roleRewardPaidOut[senderRole] = true; 
 
-    if (_currency == Currency.ETH) {
+    if (a.currency == Currency.ETH) {
       msg.sender.transfer(reward);
-    } else if (_currency == Currency.GALT) {
+    } else if (a.currency == Currency.GALT) {
       galtToken.transfer(msg.sender, reward);
     } else {
       revert("Unknown currency");
@@ -638,8 +636,7 @@ contract PlotManager is Initializable, Ownable {
   }
 
   function claimGaltSpaceReward(
-    bytes32 _aId,
-    Currency _currency
+    bytes32 _aId
   )
     external
   {
@@ -652,13 +649,12 @@ contract PlotManager is Initializable, Ownable {
       "Application status should be ether APPROVED or DISASSEMBLED_BY_VALIDATOR");
     require(a.galtSpaceReward > 0, "Reward is 0");
     require(a.galtSpaceRewardPaidOut == false, "Reward is already paid out");
-    require(a.currency == _currency, "Reward currency doesn't match");
 
     a.galtSpaceRewardPaidOut = true;
 
-    if (_currency == Currency.ETH) {
+    if (a.currency == Currency.ETH) {
       msg.sender.transfer(a.galtSpaceReward);
-    } else if (_currency == Currency.GALT) {
+    } else if (a.currency == Currency.GALT) {
       galtToken.transfer(msg.sender, a.galtSpaceReward);
     } else {
       revert("Unknown currency");

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -422,6 +422,10 @@ contract PlotManager is Initializable, Ownable {
       "Application status should be NEW or REJECTED for this operation."
     );
 
+    if (a.status == ApplicationStatus.REVERTED) {
+      require(msg.sender == a.applicant, "Only applicant is allowed to disassemble REVERTED applications");
+    }
+
     require(
       a.applicant == msg.sender ||
       (a.addressRoles[msg.sender] != 0x0 && validators.isValidatorActive(msg.sender)),

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -159,30 +159,30 @@ contract PlotManager is Initializable, Ownable {
   }
 
   // TODO: fix incorrect meaning
-  function setGaltSpaceRewardsAddress(address _newAddress) public onlyOwner {
+  function setGaltSpaceRewardsAddress(address _newAddress) external onlyOwner {
     galtSpaceRewardsAddress = _newAddress;
   }
 
-  function setPaymentMethod(PaymentMethod _newMethod) public onlyOwner {
+  function setPaymentMethod(PaymentMethod _newMethod) external onlyOwner {
     paymentMethod = _newMethod;
   }
 
-  function setApplicationFeeInEth(uint256 _newFee) public onlyOwner {
+  function setApplicationFeeInEth(uint256 _newFee) external onlyOwner {
     applicationFeeInEth = _newFee;
   }
 
-  function setApplicationFeeInGalt(uint256 _newFee) public onlyOwner {
+  function setApplicationFeeInGalt(uint256 _newFee) external onlyOwner {
     applicationFeeInGalt = _newFee;
   }
 
-  function setGaltSpaceEthShare(uint256 _newShare) public onlyOwner {
+  function setGaltSpaceEthShare(uint256 _newShare) external onlyOwner {
     require(_newShare >= 1, "Percent value should be greater or equal to 1");
     require(_newShare <= 100, "Percent value should be greater or equal to 100");
 
     galtSpaceEthShare = _newShare;
   }
 
-  function setGaltSpaceGaltShare(uint256 _newShare) public onlyOwner {
+  function setGaltSpaceGaltShare(uint256 _newShare) external onlyOwner {
     require(_newShare >= 1, "Percent value should be greater or equal to 1");
     require(_newShare <= 100, "Percent value should be greater or equal to 100");
 
@@ -196,10 +196,6 @@ contract PlotManager is Initializable, Ownable {
     a.operator = _to;
   }
 
-  function getApplicationOperator(bytes32 _aId) public view returns (address) {
-    return applications[_aId].operator;
-  }
-
   function changeApplicationDetails(
     bytes32 _aId,
     bytes32 _credentialsHash,
@@ -207,7 +203,7 @@ contract PlotManager is Initializable, Ownable {
     uint8 _precision,
     bytes2 _country
   )
-    public
+    external
     onlyApplicant(_aId)
   {
     Application storage a = applications[_aId];
@@ -231,7 +227,7 @@ contract PlotManager is Initializable, Ownable {
     uint8 _precision,
     uint256 _applicationFeeInGalt
   )
-    public
+    external
     ready
     returns (bytes32)
   {
@@ -451,7 +447,7 @@ contract PlotManager is Initializable, Ownable {
     }
   }
 
-  function submitApplication(bytes32 _aId) public onlyApplicant(_aId) {
+  function submitApplication(bytes32 _aId) external onlyApplicant(_aId) {
     Application storage a = applications[_aId];
 
     require(
@@ -462,7 +458,7 @@ contract PlotManager is Initializable, Ownable {
   }
 
   // Application can be locked by a role only once.
-  function lockApplicationForReview(bytes32 _aId, bytes32 _role) public anyValidator {
+  function lockApplicationForReview(bytes32 _aId, bytes32 _role) external anyValidator {
     Application storage a = applications[_aId];
     require(validators.hasRole(msg.sender, _role), "Unable to lock with given roles");
 
@@ -479,7 +475,7 @@ contract PlotManager is Initializable, Ownable {
     changeValidationStatus(a, _role, ValidationStatus.LOCKED);
   }
 
-  function resetApplicationRole(bytes32 _aId, bytes32 _role) public onlyOwner {
+  function resetApplicationRole(bytes32 _aId, bytes32 _role) external onlyOwner {
     Application storage a = applications[_aId];
     require(
       a.status == ApplicationStatus.SUBMITTED,
@@ -496,7 +492,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _aId,
     bytes32 _credentialsHash
   )
-    public
+    external
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -533,7 +529,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _aId,
     string _message
   )
-    public
+    external
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -561,7 +557,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _aId,
     string _message
   )
-    public
+    external
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -584,7 +580,7 @@ contract PlotManager is Initializable, Ownable {
     changeApplicationStatus(a, ApplicationStatus.REVERTED);
   }
 
-  function revokeApplication(bytes32 _aId) public onlyApplicant(_aId) {
+  function revokeApplication(bytes32 _aId) external onlyApplicant(_aId) {
     Application storage a = applications[_aId];
 
     require(
@@ -610,7 +606,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _aId,
     Currency _currency
   )
-    public 
+    external 
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -641,7 +637,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _aId,
     Currency _currency
   )
-    public
+    external
   {
     require(msg.sender == galtSpaceRewardsAddress, "The method call allowed only for galtSpace address");
 
@@ -693,7 +689,7 @@ contract PlotManager is Initializable, Ownable {
     bytes32 _id,
     bytes32 _hash
   )
-    public
+    external
     view
     returns (bool)
   {
@@ -703,7 +699,7 @@ contract PlotManager is Initializable, Ownable {
   function getApplicationById(
     bytes32 _id
   )
-    public
+    external
     view
     returns (
       address applicant,
@@ -737,7 +733,7 @@ contract PlotManager is Initializable, Ownable {
   function getApplicationFinanceById(
     bytes32 _id
   )
-    public
+    external
     view
     returns (
       ApplicationStatus status,
@@ -768,6 +764,10 @@ contract PlotManager is Initializable, Ownable {
 
   function getApplicationsByValidator(address _applicant) external view returns (bytes32[]) {
     return applicationsByValidator[_applicant];
+  }
+
+  function getApplicationOperator(bytes32 _aId) public view returns (address) {
+    return applications[_aId].operator;
   }
 
   function getApplicationValidator(

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -266,13 +266,13 @@ contract PlotManager is Initializable, Ownable {
     if (msg.value > 0) {
       require(_applicationFeeInGalt == 0, "Could not accept both ETH and GALT");
       require(msg.value >= minimalApplicationFeeInEth, "Incorrect fee passed in");
-      fee =  msg.value;
+      fee = msg.value;
     // GALT
     } else {
       require(msg.value == 0, "Could not accept both ETH and GALT");
       require(_applicationFeeInGalt >= minimalApplicationFeeInGalt, "Incorrect fee passed in");
       galtToken.transferFrom(msg.sender, address(this), _applicationFeeInGalt);
-      fee =  _applicationFeeInGalt;
+      fee = _applicationFeeInGalt;
       currency = Currency.GALT;
     }
 
@@ -328,9 +328,9 @@ contract PlotManager is Initializable, Ownable {
     uint256 share;
 
     if (_a.currency == Currency.ETH) {
-      share =  galtSpaceEthShare;
+      share = galtSpaceEthShare;
     } else {
-      share =  galtSpaceGaltShare;
+      share = galtSpaceGaltShare;
     }
 
     uint256 galtSpaceReward = share.mul(_fee).div(100);

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -458,8 +458,12 @@ contract PlotManager is Initializable, Ownable {
       a.status == ApplicationStatus.NEW || a.status == ApplicationStatus.REVERTED,
       "Application status should be NEW");
 
-    uint256 expectedDepositInEth = a.gasDepositEstimation.mul(gasPriceForDeposits);
-    require(msg.value == expectedDepositInEth, "Incorrect gas deposit");
+    if (a.status == ApplicationStatus.NEW) {
+      uint256 expectedDepositInEth = a.gasDepositEstimation.mul(gasPriceForDeposits);
+      require(msg.value == expectedDepositInEth, "Incorrect gas deposit");
+    } else {
+      require(msg.value == 0, "No deposit required on re-submition");
+    }
 
     changeApplicationStatus(a, ApplicationStatus.SUBMITTED);
   }

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -311,7 +311,7 @@ contract PlotManager is Initializable, Ownable {
     assert(totalReward == a.validatorsReward);
   }
 
-  function applyForPlotOwnership(
+  function applyForPlotOwnershipEth(
     uint256[] _packageContour,
     uint256 _baseGeohash,
     bytes32 _credentialsHash,

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -61,6 +61,7 @@ contract PlotManager is Initializable, Ownable {
     uint256 packageTokenId;
     uint256 validatorsReward;
     uint256 galtSpaceReward;
+    uint256 gasDepositEstimation;
     bool galtSpaceRewardPaidOut;
     uint8 precision;
     bytes2 country;
@@ -362,6 +363,8 @@ contract PlotManager is Initializable, Ownable {
       "Application status should be NEW or REVERTED."
     );
 
+    uint256 initGas = gasleft();
+
     for (uint8 i = 0; i < _geohashes.length; i++) {
       uint256 geohashTokenId = spaceToken.geohashToTokenId(_geohashes[i]);
       if (spaceToken.exists(geohashTokenId)) {
@@ -377,6 +380,8 @@ contract PlotManager is Initializable, Ownable {
     }
 
     splitMerge.addGeohashesToPackage(a.packageTokenId, _geohashes, _neighborsGeohashTokens, _directions);
+
+    a.gasDepositEstimation = a.gasDepositEstimation.add(initGas.sub(gasleft()));
   }
 
   function removeGeohashesFromApplication(
@@ -673,6 +678,7 @@ contract PlotManager is Initializable, Ownable {
     returns (
       address applicant,
       uint256 packageTokenId,
+      uint256 gasDepositEstimation,
       bytes32 credentialsHash,
       ApplicationStatus status,
       Currency currency,
@@ -689,6 +695,7 @@ contract PlotManager is Initializable, Ownable {
     return (
       m.applicant,
       m.packageTokenId,
+      m.gasDepositEstimation,
       m.credentialsHash,
       m.status,
       m.currency,

--- a/contracts/PlotManager.sol
+++ b/contracts/PlotManager.sol
@@ -79,8 +79,8 @@ contract PlotManager is Initializable, Ownable {
   }
 
   PaymentMethod public paymentMethod;
-  uint256 public applicationFeeInEth;
-  uint256 public applicationFeeInGalt;
+  uint256 public minimalApplicationFeeInEth;
+  uint256 public minimalApplicationFeeInGalt;
   uint256 public galtSpaceEthShare;
   uint256 public galtSpaceGaltShare;
   address private galtSpaceRewardsAddress;
@@ -122,8 +122,8 @@ contract PlotManager is Initializable, Ownable {
 
     // Default values for revenue shares and application fees
     // Override them using one of the corresponding setters
-    applicationFeeInEth = 1;
-    applicationFeeInGalt = 10;
+    minimalApplicationFeeInEth = 1;
+    minimalApplicationFeeInGalt = 10;
     galtSpaceEthShare = 33;
     galtSpaceGaltShare = 33;
     paymentMethod = PaymentMethod.ETH_AND_GALT;
@@ -176,12 +176,12 @@ contract PlotManager is Initializable, Ownable {
     paymentMethod = _newMethod;
   }
 
-  function setApplicationFeeInEth(uint256 _newFee) external onlyFeeManager {
-    applicationFeeInEth = _newFee;
+  function setMinimalApplicationFeeInEth(uint256 _newFee) external onlyFeeManager {
+    minimalApplicationFeeInEth = _newFee;
   }
 
-  function setApplicationFeeInGalt(uint256 _newFee) external onlyFeeManager {
-    applicationFeeInGalt = _newFee;
+  function setMinimalApplicationFeeInGalt(uint256 _newFee) external onlyFeeManager {
+    minimalApplicationFeeInGalt = _newFee;
   }
 
   function setGaltSpaceEthShare(uint256 _newShare) external onlyFeeManager {
@@ -252,12 +252,12 @@ contract PlotManager is Initializable, Ownable {
     // ETH
     if (msg.value > 0) {
       require(_applicationFeeInGalt == 0, "Could not accept both ETH and GALT");
-      require(msg.value >= applicationFeeInEth, "Incorrect fee passed in");
+      require(msg.value >= minimalApplicationFeeInEth, "Incorrect fee passed in");
       fee =  msg.value;
     // GALT
     } else {
       require(msg.value == 0, "Could not accept both ETH and GALT");
-      require(_applicationFeeInGalt >= applicationFeeInGalt, "Incorrect fee passed in");
+      require(_applicationFeeInGalt >= minimalApplicationFeeInGalt, "Incorrect fee passed in");
       galtToken.transferFrom(msg.sender, address(this), _applicationFeeInGalt);
       fee =  _applicationFeeInGalt;
       currency = Currency.GALT;
@@ -302,7 +302,6 @@ contract PlotManager is Initializable, Ownable {
     return _id;
   }
 
-  // >>>>>>>>
   function calculateAndStoreFee(
     Application memory _a,
     uint256 _fee
@@ -326,7 +325,6 @@ contract PlotManager is Initializable, Ownable {
     _a.galtSpaceReward = galtSpaceReward;
   }
 
-  // >>>>>>>>
   function assignRequiredValidatorRolesAndRewards(bytes32 _aId) internal {
     Application storage a = applications[_aId];
     assert(a.validatorsReward > 0);

--- a/contracts/SpaceToken.sol
+++ b/contracts/SpaceToken.sol
@@ -122,7 +122,7 @@ contract SpaceToken is ERC721Token, Ownable, RBAC, Initializable {
   function mintPack(
     address _to
   )
-    public
+    external
     onlyMinter
     returns (uint256)
   {
@@ -137,7 +137,7 @@ contract SpaceToken is ERC721Token, Ownable, RBAC, Initializable {
     address _to,
     uint256 _geohash5
   )
-    public
+    external
     onlyMinter
     returns (uint256)
   {
@@ -272,11 +272,11 @@ contract SpaceToken is ERC721Token, Ownable, RBAC, Initializable {
     return newId;
   }
 
-  function addRoleTo(address _operator, string _role) public onlyOwner {
+  function addRoleTo(address _operator, string _role) external onlyOwner {
     super.addRole(_operator, _role);
   }
 
-  function removeRoleFrom(address _operator, string _role) public onlyOwner {
+  function removeRoleFrom(address _operator, string _role) external onlyOwner {
     super.removeRole(_operator, _role);
   }
 }

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -73,7 +73,7 @@ contract Validators is Ownable {
     uint8[] _shares,
     bytes32[] _descriptions
   )
-    public
+    external
     onlyOwner
   {
     uint8 len = uint8(_roles.length);
@@ -106,7 +106,7 @@ contract Validators is Ownable {
   function deleteApplicationType(
     bytes32 _applicationType
   )
-    public
+    external
     onlyOwner
   {
     bytes32[] memory aRoles = applicationTypeRoles[_applicationType];
@@ -119,14 +119,14 @@ contract Validators is Ownable {
     delete applicationTypeRoles[_applicationType];
   }
 
-  function isApplicationTypeReady(bytes32 _applicationType) public view returns (bool) {
+  function isApplicationTypeReady(bytes32 _applicationType) external view returns (bool) {
     return applicationTypeRoles[_applicationType].length > 0;
   }
 
   function getApplicationTypeRoles(
     bytes32 _applicationType
   )
-    public
+    external
     view
     returns (bytes32[])
   {
@@ -136,7 +136,7 @@ contract Validators is Ownable {
   function getApplicationTypeRolesCount(
     bytes32 _applicationType
   )
-    public
+    external
     view
     returns (uint256)
   {
@@ -145,11 +145,11 @@ contract Validators is Ownable {
     return count;
   }
 
-  function getRoleRewardShare(bytes32 _role) public view returns (uint8) {
+  function getRoleRewardShare(bytes32 _role) external view returns (uint8) {
     return roles[_role].rewardShare;
   }
 
-  function getRoleApplicationType(bytes32 _role) public view returns (bytes32) {
+  function getRoleApplicationType(bytes32 _role) external view returns (bytes32) {
     return roles[_role].applicationType;
   }
 
@@ -161,7 +161,7 @@ contract Validators is Ownable {
     bytes32[] _descriptionHashes,
     bytes32[] _roles
   )
-    public
+    external
     onlyOwner
   {
     require(_validator != address(0), "Validator address is empty");
@@ -185,28 +185,28 @@ contract Validators is Ownable {
     validatorsArray.push(_validator);
   }
 
-  function removeValidator(address _validator) public onlyOwner {
+  function removeValidator(address _validator) external onlyOwner {
     require(_validator != address(0), "Missing validator");
     // TODO: use index to remove validator
     validators[_validator].active = false;
   }
 
-  function ensureValidatorActive(address _validator) public view returns (bool) {
+  function ensureValidatorActive(address _validator) external view returns (bool) {
     require(validators[_validator].active == true, "Validator is not active");
   }
 
-  function isValidatorActive(address _validator) public view returns (bool) {
+  function isValidatorActive(address _validator) external view returns (bool) {
     return validators[_validator].active == true;
   }
 
-  function hasRole(address _validator, bytes32 _role) public view returns (bool) {
+  function hasRole(address _validator, bytes32 _role) external view returns (bool) {
     return validators[_validator].roles[_role] == true;
   }
 
   function getValidator(
     address validator
   )
-    public
+    external
     view
     returns (
       bytes32 name,
@@ -223,7 +223,7 @@ contract Validators is Ownable {
     );
   }
 
-  function getValidatorRoles() public view returns (bytes32[]) {
+  function getValidatorRoles() external view returns (bytes32[]) {
     return validatorRolesIndex;
   }
 }

--- a/contracts/Validators.sol
+++ b/contracts/Validators.sol
@@ -211,6 +211,7 @@ contract Validators is Ownable {
     returns (
       bytes32 name,
       bytes32 position,
+      bytes32[] roles,
       bool active
     )
   {
@@ -219,6 +220,7 @@ contract Validators is Ownable {
     return (
     v.name,
     v.position,
+    v.rolesList,
     v.active
     );
   }

--- a/scripts/checkContractSize.js
+++ b/scripts/checkContractSize.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+console.log('\nSize limit is about', 24577, '\n');
+checkSize('PlotManager');
+checkSize('PlotClarificationManager');
+checkSize('SplitMerge');
+checkSize('SpaceToken');
+checkSize('GaltToken');
+checkSize('GaltDex');
+checkSize('Validators');
+console.log('\n');
+
+function checkSize(contract) {
+  let abi;
+  try {
+    abi = JSON.parse(fs.readFileSync(`build/contracts/${contract}.json`));
+  } catch (e) {
+    return;
+  }
+  console.log(contract, Buffer.byteLength(abi.deployedBytecode, 'utf8') / 2, 'bytes');
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,6 +12,9 @@ module.exports = {
   hex(input) {
     return web3.utils.toHex(input);
   },
+  gwei(number) {
+    return web3.utils.toWei(number.toString(), 'gwei');
+  },
   szabo(number) {
     return web3.utils.toWei(number.toString(), 'szabo');
   },

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -219,13 +219,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
 
       assert(await this.validators.isApplicationTypeReady(NEW_APPLICATION));
 
-      const res = await this.plotManager.applyForPlotOwnershipEth(
+      const res = await this.plotManager.applyForPlotOwnership(
         this.contour,
         galt.geohashToGeohash5('sezu06'),
         this.credentials,
         this.ledgerIdentifier,
         web3.utils.asciiToHex('MN'),
         7,
+        0,
         { from: alice, value: ether(6) }
       );
 
@@ -347,7 +348,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         { from: coreTeam }
       );
       await this.galtToken.approve(this.plotManager.address, ether(47), { from: alice });
-      const res = await this.plotManager.applyForPlotOwnershipGalt(
+      const res = await this.plotManager.applyForPlotOwnership(
         this.contour,
         galt.geohashToGeohash5('sezu06'),
         this.credentials,
@@ -361,7 +362,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       this.aId = res.logs[0].args.id;
     });
 
-    describe('#applyForPlotOwnershipGalt()', () => {
+    describe('#applyForPlotOwnership() Galt', () => {
       it('should provide methods to create and read an application', async function() {
         const res2 = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
         const res3 = await this.splitMerge.getPackageContour(
@@ -407,7 +408,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         it('should reject fees less than the minial', async function() {
           await this.galtToken.approve(this.plotManager.address, ether(37), { from: alice });
           await assertRevert(
-            this.plotManager.applyForPlotOwnershipGalt(
+            this.plotManager.applyForPlotOwnership(
               this.contour,
               galt.geohashToGeohash5('sezu07'),
               this.credentials,
@@ -422,7 +423,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
 
         it('accept fees greater than the minimal', async function() {
           await this.galtToken.approve(this.plotManager.address, ether(87), { from: alice });
-          const res = await this.plotManager.applyForPlotOwnershipGalt(
+          const res = await this.plotManager.applyForPlotOwnership(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
@@ -447,7 +448,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
           );
 
           await this.galtToken.approve(this.plotManager.address, ether(53), { from: alice });
-          let res = await this.plotManager.applyForPlotOwnershipGalt(
+          let res = await this.plotManager.applyForPlotOwnership(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
@@ -550,7 +551,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         );
 
         await this.galtToken.approve(this.plotManager.address, ether(57), { from: alice });
-        let res = await this.plotManager.applyForPlotOwnershipGalt(
+        let res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu07'),
           this.credentials,
@@ -668,13 +669,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         { from: coreTeam }
       );
 
-      let res = await this.plotManager.applyForPlotOwnershipEth(
+      let res = await this.plotManager.applyForPlotOwnership(
         this.contour,
         galt.geohashToGeohash5('sezu06'),
         this.credentials,
         this.ledgerIdentifier,
         web3.utils.asciiToHex('MN'),
         7,
+        0,
         { from: alice, value: ether(6) }
       );
 
@@ -691,7 +693,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       await this.validators.addValidator(eve, 'Eve', 'MN', [], ['dog'], { from: coreTeam });
     });
 
-    describe('#applyForPlotOwnershipEth()', () => {
+    describe('#applyForPlotOwnership() ETH', () => {
       it('should provide methods to create and read an application', async function() {
         const res2 = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
         const res3 = await this.splitMerge.getPackageContour(
@@ -729,13 +731,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       describe('payable', () => {
         it('should reject applications without payment', async function() {
           await assertRevert(
-            this.plotManager.applyForPlotOwnershipEth(
+            this.plotManager.applyForPlotOwnership(
               this.contour,
               galt.geohashToGeohash5('sezu06'),
               this.credentials,
               this.ledgerIdentifier,
               web3.utils.asciiToHex('MN'),
               7,
+              0,
               { from: alice }
             )
           );
@@ -743,26 +746,28 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
 
         it('should reject applications with payment less than required', async function() {
           await assertRevert(
-            this.plotManager.applyForPlotOwnershipEth(
+            this.plotManager.applyForPlotOwnership(
               this.contour,
               galt.geohashToGeohash5('sezu06'),
               this.credentials,
               this.ledgerIdentifier,
               web3.utils.asciiToHex('MN'),
               7,
+              0,
               { from: alice, value: ether(3) }
             )
           );
         });
 
         it('should allow applications with payment greater than required', async function() {
-          await this.plotManager.applyForPlotOwnershipEth(
+          await this.plotManager.applyForPlotOwnership(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
             this.ledgerIdentifier,
             web3.utils.asciiToHex('MN'),
             7,
+            0,
             { from: alice, value: ether(7) }
           );
         });
@@ -784,13 +789,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
             { from: coreTeam }
           );
 
-          let res = await this.plotManager.applyForPlotOwnershipEth(
+          let res = await this.plotManager.applyForPlotOwnership(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
             this.ledgerIdentifier,
             web3.utils.asciiToHex('MN'),
             7,
+            0,
             { from: alice, value: ether(9) }
           );
           const aId = res.logs[0].args.id;
@@ -1098,13 +1104,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
 
       it('should push an application id to the validators list for caching', async function() {
         // submit first
-        let res = await this.plotManager.applyForPlotOwnershipEth(
+        let res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu19'),
           this.credentials,
           this.ledgerIdentifier,
           web3.utils.asciiToHex('MN'),
           7,
+          0,
           { from: charlie, value: ether(6) }
         );
         const a1Id = res.logs[0].args.id;
@@ -1114,13 +1121,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         await this.plotManager.lockApplicationForReview(a1Id, 'human', { from: bob });
 
         // submit second
-        res = await this.plotManager.applyForPlotOwnershipEth(
+        res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu09'),
           this.credentials,
           this.ledgerIdentifier,
           web3.utils.asciiToHex('MN'),
           7,
+          0,
           { from: alice, value: ether(6) }
         );
         const a2Id = res.logs[0].args.id;
@@ -1136,13 +1144,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       });
 
       it('should deny validator to lock an application which is new', async function() {
-        let res = await this.plotManager.applyForPlotOwnershipEth(
+        let res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu05'),
           this.credentials,
           this.ledgerIdentifier,
           web3.utils.asciiToHex('MN'),
           7,
+          0,
           { from: alice, value: ether(6) }
         );
         const a2Id = res.logs[0].args.id;
@@ -1262,13 +1271,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
 
       // eslint-disable-next-line
       it('should deny validator approve application with other than consideration or partially locked status', async function() {
-        let res = await this.plotManager.applyForPlotOwnershipEth(
+        let res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu36'),
           this.credentials,
           this.ledgerIdentifier,
           web3.utils.asciiToHex('MN'),
           7,
+          0,
           { from: alice, value: ether(6) }
         );
 
@@ -1331,13 +1341,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       });
 
       it('should deny validator revert an application with non-consideration status', async function() {
-        let res = await this.plotManager.applyForPlotOwnershipEth(
+        let res = await this.plotManager.applyForPlotOwnership(
           this.contour,
           galt.geohashToGeohash5('sezu96'),
           this.credentials,
           this.ledgerIdentifier,
           web3.utils.asciiToHex('MN'),
           7,
+          0,
           { from: alice, value: ether(6) }
         );
         const aId = res.logs[0].args.id;
@@ -1475,18 +1486,12 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
           assert.equal(res, 18);
         });
 
-        it('can be disassembled by any validator role', async function() {
-          let res;
-
-          await this.plotManager.removeGeohashesFromApplication(this.aId, this.geohashesToRemove, [], [], {
-            from: dan
-          });
-
-          res = await this.splitMerge.getPackageGeohashesCount(this.packageTokenId);
-          assert.equal(res, 0);
-
-          res = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
-          assert.equal(res.status, ApplicationStatus.DISASSEMBLED_BY_VALIDATOR);
+        it('cant be disassembled by any validator role', async function() {
+          await assertRevert(
+            this.plotManager.removeGeohashesFromApplication(this.aId, this.geohashesToRemove, [], [], {
+              from: dan
+            })
+          );
         });
 
         it('can be disassembled by an applicant', async function() {

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -218,7 +218,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
 
       assert(await this.validators.isApplicationTypeReady(NEW_APPLICATION));
 
-      const res = await this.plotManager.applyForPlotOwnership(
+      const res = await this.plotManager.applyForPlotOwnershipEth(
         this.contour,
         galt.geohashToGeohash5('sezu06'),
         this.credentials,
@@ -657,7 +657,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
         { from: coreTeam }
       );
 
-      let res = await this.plotManager.applyForPlotOwnership(
+      let res = await this.plotManager.applyForPlotOwnershipEth(
         this.contour,
         galt.geohashToGeohash5('sezu06'),
         this.credentials,
@@ -680,7 +680,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
       await this.validators.addValidator(eve, 'Eve', 'MN', [], ['dog'], { from: coreTeam });
     });
 
-    describe('#applyForPlotOwnership()', () => {
+    describe('#applyForPlotOwnershipEth()', () => {
       it('should provide methods to create and read an application', async function() {
         const res2 = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
         const res3 = await this.splitMerge.getPackageContour(
@@ -718,7 +718,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
       describe('payable', () => {
         it('should reject applications without payment', async function() {
           await assertRevert(
-            this.plotManager.applyForPlotOwnership(
+            this.plotManager.applyForPlotOwnershipEth(
               this.contour,
               galt.geohashToGeohash5('sezu06'),
               this.credentials,
@@ -732,7 +732,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
 
         it('should reject applications with payment less than required', async function() {
           await assertRevert(
-            this.plotManager.applyForPlotOwnership(
+            this.plotManager.applyForPlotOwnershipEth(
               this.contour,
               galt.geohashToGeohash5('sezu06'),
               this.credentials,
@@ -745,7 +745,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
         });
 
         it('should allow applications with payment greater than required', async function() {
-          await this.plotManager.applyForPlotOwnership(
+          await this.plotManager.applyForPlotOwnershipEth(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
@@ -773,7 +773,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
             { from: coreTeam }
           );
 
-          let res = await this.plotManager.applyForPlotOwnership(
+          let res = await this.plotManager.applyForPlotOwnershipEth(
             this.contour,
             galt.geohashToGeohash5('sezu07'),
             this.credentials,
@@ -1087,7 +1087,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
 
       it('should push an application id to the validators list for caching', async function() {
         // submit first
-        let res = await this.plotManager.applyForPlotOwnership(
+        let res = await this.plotManager.applyForPlotOwnershipEth(
           this.contour,
           galt.geohashToGeohash5('sezu19'),
           this.credentials,
@@ -1103,7 +1103,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
         await this.plotManager.lockApplicationForReview(a1Id, 'human', { from: bob });
 
         // submit second
-        res = await this.plotManager.applyForPlotOwnership(
+        res = await this.plotManager.applyForPlotOwnershipEth(
           this.contour,
           galt.geohashToGeohash5('sezu09'),
           this.credentials,
@@ -1125,7 +1125,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
       });
 
       it('should deny validator to lock an application which is new', async function() {
-        let res = await this.plotManager.applyForPlotOwnership(
+        let res = await this.plotManager.applyForPlotOwnershipEth(
           this.contour,
           galt.geohashToGeohash5('sezu05'),
           this.credentials,
@@ -1251,7 +1251,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
 
       // eslint-disable-next-line
       it('should deny validator approve application with other than consideration or partially locked status', async function() {
-        let res = await this.plotManager.applyForPlotOwnership(
+        let res = await this.plotManager.applyForPlotOwnershipEth(
           this.contour,
           galt.geohashToGeohash5('sezu36'),
           this.credentials,
@@ -1320,7 +1320,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
       });
 
       it('should deny validator revert an application with non-consideration status', async function() {
-        let res = await this.plotManager.applyForPlotOwnership(
+        let res = await this.plotManager.applyForPlotOwnershipEth(
           this.contour,
           galt.geohashToGeohash5('sezu96'),
           this.credentials,

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -841,6 +841,22 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
         await this.plotManager.addGeohashesToApplication(this.aId, geohashes, [], [], { from: frank });
       });
 
+      it('should add a list of geohashes', async function() {
+        let geohashes1 = `gbsuv7ztt gbsuv7ztw gbsuv7ztx gbsuv7ztm gbsuv7ztq gbsuv7ztr gbsuv7ztj gbsuv7ztn`;
+        let geohashes2 = `gbsuv7zq gbsuv7zw gbsuv7zy gbsuv7zm gbsuv7zt gbsuv7zv gbsuv7zk gbsuv7zs gbsuv7zu`;
+        geohashes1 = geohashes1.split(' ').map(galt.geohashToGeohash5);
+        geohashes2 = geohashes2.split(' ').map(galt.geohashToGeohash5);
+
+        // TODO: pass neighbours and directions
+        await this.plotManager.addGeohashesToApplication(this.aId, geohashes1, [], [], { from: alice });
+        let res = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
+        const firstAddGas = res.gasDepositEstimation;
+
+        await this.plotManager.addGeohashesToApplication(this.aId, geohashes2, [], [], { from: alice });
+        res = await this.plotManagerWeb3.methods.getApplicationById(this.aId).call();
+        assert(res.gasDepositEstimation > firstAddGas);
+      });
+
       it('should re-use geohash space tokens if they belong to PlotManager', async function() {
         const tokenId = galt.geohashToNumber('sezu05');
         let res = await this.spaceToken.mintGeohash(this.plotManager.address, tokenId.toString(10), {

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -95,8 +95,8 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
     await this.splitMerge.initialize(this.spaceToken.address, this.plotManager.address, { from: coreTeam });
     await this.plotManager.setFeeManager(feeManager, true, { from: coreTeam });
 
-    await this.plotManager.setApplicationFeeInEth(ether(6), { from: feeManager });
-    await this.plotManager.setApplicationFeeInGalt(ether(45), { from: feeManager });
+    await this.plotManager.setMinimalApplicationFeeInEth(ether(6), { from: feeManager });
+    await this.plotManager.setMinimalApplicationFeeInGalt(ether(45), { from: feeManager });
     await this.plotManager.setGaltSpaceEthShare(33, { from: feeManager });
     await this.plotManager.setGaltSpaceGaltShare(13, { from: feeManager });
 
@@ -112,7 +112,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
   });
 
   it('should be initialized successfully', async function() {
-    (await this.plotManager.applicationFeeInEth()).toString(10).should.be.a.bignumber.eq(ether(6));
+    (await this.plotManager.minimalApplicationFeeInEth()).toString(10).should.be.a.bignumber.eq(ether(6));
   });
 
   describe('contract config modifiers', () => {
@@ -142,27 +142,27 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, feeManager, alice, bob, charli
       });
     });
 
-    describe('#setApplicationFeeInEth()', () => {
+    describe('#setMinimalApplicationFeeInEth()', () => {
       it('should allow a fee manager set a new minimum fee in ETH', async function() {
-        await this.plotManager.setApplicationFeeInEth(ether(0.05), { from: feeManager });
-        const res = await this.plotManager.applicationFeeInEth();
+        await this.plotManager.setMinimalApplicationFeeInEth(ether(0.05), { from: feeManager });
+        const res = await this.plotManager.minimalApplicationFeeInEth();
         assert.equal(res, ether(0.05));
       });
 
       it('should deny any other than a fee manager account set fee in ETH', async function() {
-        await assertRevert(this.plotManager.setApplicationFeeInEth(ether(0.05), { from: coreTeam }));
+        await assertRevert(this.plotManager.setMinimalApplicationFeeInEth(ether(0.05), { from: coreTeam }));
       });
     });
 
-    describe('#setApplicationFeeInGalt()', () => {
+    describe('#setMinimalApplicationFeeInGalt()', () => {
       it('should allow a fee manager set a new minimum fee in GALT', async function() {
-        await this.plotManager.setApplicationFeeInGalt(ether(0.15), { from: feeManager });
-        const res = await this.plotManager.applicationFeeInGalt();
+        await this.plotManager.setMinimalApplicationFeeInGalt(ether(0.15), { from: feeManager });
+        const res = await this.plotManager.minimalApplicationFeeInGalt();
         assert.equal(res, ether(0.15));
       });
 
       it('should deny any other than a fee manager account set fee in GALT', async function() {
-        await assertRevert(this.plotManager.setApplicationFeeInGalt(ether(0.15), { from: coreTeam }));
+        await assertRevert(this.plotManager.setMinimalApplicationFeeInGalt(ether(0.15), { from: coreTeam }));
       });
     });
 

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -502,7 +502,7 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
       });
 
       describe('with status REVERTED', () => {
-        it('should change status to REVOKED and give refund', async function() {
+        beforeEach(async function() {
           await this.validators.addValidator(charlie, 'Charlie', 'MN', [], ['🦄'], { from: coreTeam });
           await this.validators.addValidator(dan, 'Dan', 'MN', [], ['🦆'], { from: coreTeam });
           await this.validators.addValidator(eve, 'Eve', 'MN', [], ['🦋'], { from: coreTeam });
@@ -510,7 +510,9 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
           await this.plotManager.submitApplication(this.aId, { from: alice });
           await this.plotManager.lockApplicationForReview(this.aId, '🦄', { from: charlie });
           await this.plotManager.revertApplication(this.aId, 'dont like it', { from: charlie });
+        });
 
+        it('should change status to REVOKED and give refund', async function() {
           await this.plotManager.removeGeohashesFromApplication(this.aId, this.geohashToRemove, [], [], {
             from: alice
           });
@@ -523,6 +525,14 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
           assert.equal(res.status, ApplicationStatus.REVOKED);
 
           assertEqualBN(aliceFinalBalance, aliceInitialBalance.add(new BN('47000000000000000000')));
+        });
+
+        it('should deny any validator disassemble REVERTed application', async function() {
+          await assertRevert(
+            this.plotManager.removeGeohashesFromApplication(this.aId, this.geohashToRemove, [], [], {
+              from: charlie
+            })
+          );
         });
       });
     });

--- a/test/integration/testPlotManager.js
+++ b/test/integration/testPlotManager.js
@@ -590,10 +590,10 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
           const evesInitialBalance = new BN((await this.galtToken.balanceOf(eve)).toString());
           const orgsInitialBalance = new BN((await this.galtToken.balanceOf(galtSpaceOrg)).toString());
 
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: bob });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: dan });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: eve });
-          await this.plotManager.claimGaltSpaceReward(this.aId, Currency.GALT, { from: galtSpaceOrg });
+          await this.plotManager.claimValidatorReward(this.aId, { from: bob });
+          await this.plotManager.claimValidatorReward(this.aId, { from: dan });
+          await this.plotManager.claimValidatorReward(this.aId, { from: eve });
+          await this.plotManager.claimGaltSpaceReward(this.aId, { from: galtSpaceOrg });
 
           const bobsFinalBalance = new BN((await this.galtToken.balanceOf(bob)).toString());
           const dansFinalBalance = new BN((await this.galtToken.balanceOf(dan)).toString());
@@ -633,10 +633,10 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
           const evesInitialBalance = new BN((await this.galtToken.balanceOf(eve)).toString());
           const orgsInitialBalance = new BN((await this.galtToken.balanceOf(galtSpaceOrg)).toString());
 
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: bob });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: dan });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.GALT, { from: eve });
-          await this.plotManager.claimGaltSpaceReward(this.aId, Currency.GALT, { from: galtSpaceOrg });
+          await this.plotManager.claimValidatorReward(this.aId, { from: bob });
+          await this.plotManager.claimValidatorReward(this.aId, { from: dan });
+          await this.plotManager.claimValidatorReward(this.aId, { from: eve });
+          await this.plotManager.claimGaltSpaceReward(this.aId, { from: galtSpaceOrg });
 
           const bobsFinalBalance = new BN((await this.galtToken.balanceOf(bob)).toString());
           const dansFinalBalance = new BN((await this.galtToken.balanceOf(dan)).toString());
@@ -1595,10 +1595,10 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
           const evesInitialBalance = new BN(await web3.eth.getBalance(eve));
           const orgsInitialBalance = new BN(await web3.eth.getBalance(galtSpaceOrg));
 
-          await this.plotManager.claimValidatorReward(this.aId, Currency.ETH, { from: bob });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.ETH, { from: dan });
-          await this.plotManager.claimValidatorReward(this.aId, Currency.ETH, { from: eve });
-          await this.plotManager.claimGaltSpaceReward(this.aId, Currency.ETH, { from: galtSpaceOrg });
+          await this.plotManager.claimValidatorReward(this.aId, { from: bob });
+          await this.plotManager.claimValidatorReward(this.aId, { from: dan });
+          await this.plotManager.claimValidatorReward(this.aId, { from: eve });
+          await this.plotManager.claimGaltSpaceReward(this.aId, { from: galtSpaceOrg });
 
           const bobsFinalBalance = new BN(await web3.eth.getBalance(bob));
           const dansFinalBalance = new BN(await web3.eth.getBalance(dan));
@@ -1696,8 +1696,8 @@ contract('PlotManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve,
 
           const orgsInitialBalance = new BN(await web3.eth.getBalance(galtSpaceOrg));
           const bobsInitialBalance = new BN(await web3.eth.getBalance(bob));
-          await this.plotManager.claimValidatorReward(this.aId, Currency.ETH, { from: bob });
-          await this.plotManager.claimGaltSpaceReward(this.aId, Currency.ETH, { from: galtSpaceOrg });
+          await this.plotManager.claimValidatorReward(this.aId, { from: bob });
+          await this.plotManager.claimGaltSpaceReward(this.aId, { from: galtSpaceOrg });
           const bobsFinalBalance = new BN(await web3.eth.getBalance(bob));
           const orgsFinalBalance = new BN(await web3.eth.getBalance(galtSpaceOrg));
 


### PR DESCRIPTION
### PlotManager adjustments.

* 9864ee3 PlotManager. Fix double-payment on re-submition
* b50193d PlotManager. Add deposit claim by validator and applicant
* ea48302 PlotManager. Add gas deposit on submition
* 2dd53b0 PlotManager. Add gas calculation
* 6dbef72 PlotManager. Rename getters/setters applicationFee => minimalApplicationFee
* dc85a61 PlotManager. Merge applyForPlotOwnership ETH & GALT into a single method
* c57952c PlotManager. Add fee manager setter
* e2fe813 Update Makefile
* 09bf17f Add contract size counter
* 1b82be8 Validators. Add roles list to #getValidator()
* b9ade34 PlotManager. Remove currency param from claim*Reward methods
* 0a92f7e PlotManager. Deny validator to disassemble REVERTED application
* 7ddb9a1 PlotManager. Rename #applyForPlotOwnership() => #applyForPlotOwnershipEth()
* 431abb4 Add ValidatorState.PENDING