### PR TITLE
Add PlotClarificationManager contract

### DIFF
--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -438,6 +438,30 @@ contract PlotClarificationManager is Initializable, Ownable {
     // a.gasDepositWithdrawn = true;
   }
 
+  function claimValidatorReward(bytes32 _aId) external onlyValidatorOfApplication(_aId) {
+    Application storage a = applications[_aId];
+
+    require(a.tokenWithdrawn == true, "Token is already withdrawn");
+    // TODO: check for gas deposit withdrawn
+
+    require(
+      a.status == ApplicationStatus.REVERTED ||
+      a.status == ApplicationStatus.PACKED,
+      "ApplicationStatus should one of REVERTED or PACKED");
+
+    bytes32 role = a.addressRoles[msg.sender];
+    uint256 reward = a.assignedRewards[role];
+    a.roleRewardPaidOut[role] = true;
+
+    if (a.currency == Currency.ETH) {
+      msg.sender.transfer(reward);
+    } else if (a.currency == Currency.GALT) {
+      galtToken.transfer(msg.sender, reward);
+    } else {
+      revert("Unknown currency");
+    }
+  }
+
   function getApplicationById(
     bytes32 _id
   )

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -377,6 +377,36 @@ contract PlotClarificationManager is Initializable, Ownable {
     }
   }
 
+  function addGeohashesToApplication(
+    bytes32 _aId,
+    uint256[] _geohashes,
+    uint256[] _neighborsGeohashTokens,
+    bytes2[] _directions
+  )
+    public
+    onlyPusherRole
+  {
+    Application storage a = applications[_aId];
+
+    require(a.status == ApplicationStatus.APPROVED, "ApplicationStatus should be APPROVED");
+
+    for (uint8 i = 0; i < _geohashes.length; i++) {
+      uint256 geohashTokenId = spaceToken.geohashToTokenId(_geohashes[i]);
+      if (spaceToken.exists(geohashTokenId)) {
+        require(
+          spaceToken.ownerOf(geohashTokenId) == address(this),
+          "Existing geohash token should belongs to PlotClarificationManager contract"
+        );
+      } else {
+        spaceToken.mintGeohash(address(this), _geohashes[i]);
+      }
+
+      _geohashes[i] = geohashTokenId;
+    }
+
+    splitMerge.addGeohashesToPackage(a.packageTokenId, _geohashes, _neighborsGeohashTokens, _directions);
+  }
+
   function getApplicationById(
     bytes32 _id
   )

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -1,0 +1,245 @@
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+
+import "zos-lib/contracts/migrations/Initializable.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./SpaceToken.sol";
+import "./SplitMerge.sol";
+import "./Validators.sol";
+
+contract PlotClarificationManager is Initializable, Ownable {
+  using SafeMath for uint256;
+
+  bytes32 public constant APPLICATION_TYPE = 0x6f7c49efa4ebd19424a5018830e177875fd96b20c1ae22bc5eb7be4ac691e7b7;
+
+  enum ApplicationStatus {
+    NOT_EXISTS,
+    NEW,
+    VALIDATION_REQUIRED,
+    VALIDATION,
+    PAYMENT_REQUIRED,
+    SUBMITTED,
+    APPROVED,
+    REVERTED,
+    PACKED
+  }
+
+  enum ValidationStatus {
+    INTACT,
+    LOCKED,
+    APPROVED,
+    REVERTED
+  }
+
+  enum PaymentMethod {
+    NONE,
+    ETH_ONLY,
+    GALT_ONLY,
+    ETH_AND_GALT
+  }
+
+  enum Currency {
+    ETH,
+    GALT
+  }
+
+  event LogApplicationStatusChanged(bytes32 applicationId, ApplicationStatus status);
+  event LogValidationStatusChanged(bytes32 applicationId, bytes32 role, ValidationStatus status);
+  event LogNewApplication(bytes32 id, address applicant);
+
+  struct Application {
+    bytes32 id;
+    address applicant;
+
+    bytes32 credentialsHash;
+    bytes32 ledgerIdentifier;
+    uint256 packageTokenId;
+
+    uint256 validatorsReward;
+    uint256 galtSpaceReward;
+    uint256 valuatedGasDeposit;
+    bool galtSpaceRewardPaidOut;
+
+    uint8 precision;
+    bytes2 country;
+    Currency currency;
+    ApplicationStatus status;
+
+    bytes32[] assignedRoles;
+
+    // TODO: combine into role struct
+    mapping(bytes32 => uint256) assignedRewards;
+    mapping(bytes32 => bool) roleRewardPaidOut;
+    mapping(bytes32 => string) roleMessages;
+    mapping(bytes32 => address) roleAddresses;
+    mapping(address => bytes32) addressRoles;
+    mapping(bytes32 => ValidationStatus) validationStatus;
+  }
+
+  mapping(bytes32 => Application) public applications;
+  mapping(address => bytes32[]) public applicationsByAddresses;
+  bytes32[] private applicationsArray;
+  // WARNING: we do not remove applications from validator's list,
+  // so do not rely on this variable to verify whether validator
+  // exists or not.
+  mapping(address => bytes32[]) public applicationsByValidator;
+
+  PaymentMethod public paymentMethod;
+  uint256 public minimalApplicationFeeInEth;
+  uint256 public minimalApplicationFeeInGalt;
+  uint256 public galtSpaceEthShare;
+  uint256 public galtSpaceGaltShare;
+  address private galtSpaceRewardsAddress;
+
+
+  SpaceToken public spaceToken;
+  SplitMerge public splitMerge;
+  Validators public validators;
+  ERC20 public galtToken;
+
+  constructor () public {}
+
+  function initialize(
+    SpaceToken _spaceToken,
+    SplitMerge _splitMerge,
+    Validators _validators,
+    ERC20 _galtToken,
+    address _galtSpaceRewardsAddress
+  )
+    public
+    isInitializer
+  {
+    owner = msg.sender;
+
+    spaceToken = _spaceToken;
+    splitMerge = _splitMerge;
+    validators = _validators;
+    galtToken = _galtToken;
+    galtSpaceRewardsAddress = _galtSpaceRewardsAddress;
+
+    // Default values for revenue shares and application fees
+    // Override them using one of the corresponding setters
+    minimalApplicationFeeInEth = 1;
+    minimalApplicationFeeInGalt = 10;
+    galtSpaceEthShare = 33;
+    galtSpaceGaltShare = 33;
+    paymentMethod = PaymentMethod.ETH_AND_GALT;
+  }
+
+  function setGaltSpaceRewardsAddress(address _newAddress) public onlyOwner {
+    galtSpaceRewardsAddress = _newAddress;
+  }
+
+  function setPaymentMethod(PaymentMethod _newMethod) public onlyOwner {
+    paymentMethod = _newMethod;
+  }
+
+  function setMinimalApplicationFeeInEth(uint256 _newFee) public onlyOwner {
+    minimalApplicationFeeInEth = _newFee;
+  }
+
+  function setMinimalApplicationFeeInGalt(uint256 _newFee) public onlyOwner {
+    minimalApplicationFeeInGalt = _newFee;
+  }
+
+  function setGaltSpaceEthShare(uint256 _newShare) public onlyOwner {
+    require(_newShare >= 1, "Percent value should be greater or equal to 1");
+    require(_newShare <= 100, "Percent value should be greater or equal to 100");
+
+    galtSpaceEthShare = _newShare;
+  }
+
+  function setGaltSpaceGaltShare(uint256 _newShare) public onlyOwner {
+    require(_newShare >= 1, "Percent value should be greater or equal to 1");
+    require(_newShare <= 100, "Percent value should be greater or equal to 100");
+
+    galtSpaceGaltShare = _newShare;
+  }
+
+
+  function applyForPlotOwnership(
+    uint256 _baseGeohash,
+    bytes32 _credentialsHash,
+    bytes32 _ledgerIdentifier,
+    bytes2 _country,
+    uint8 _precision,
+    uint256 _applicationFeeInGalt
+  )
+    public
+    returns (bytes32)
+  {
+    require(_precision > 5, "Precision should be greater than 5");
+
+    galtToken.transferFrom(msg.sender, address(this), _applicationFeeInGalt);
+    // TODO: transfer space token here
+
+    Application memory a;
+    bytes32 _id = keccak256(
+      abi.encodePacked(
+        _baseGeohash,
+        _credentialsHash,
+        blockhash(block.number)
+      )
+    );
+
+    require(applications[_id].status == ApplicationStatus.NOT_EXISTS, "Application already exists");
+
+    a.status = ApplicationStatus.NEW;
+    a.id = _id;
+    a.applicant = msg.sender;
+
+    a.country = _country;
+    a.credentialsHash = _credentialsHash;
+    a.ledgerIdentifier = _ledgerIdentifier;
+    a.precision = _precision;
+
+    applications[_id] = a;
+    applicationsArray.push(_id);
+    applicationsByAddresses[msg.sender].push(_id);
+
+    emit LogNewApplication(_id, msg.sender);
+    emit LogApplicationStatusChanged(_id, ApplicationStatus.NEW);
+
+    return _id;
+  }
+
+  function getApplicationById(
+    bytes32 _id
+  )
+    public
+    view
+    returns (
+      address applicant,
+      uint256 packageTokenId,
+      bytes32 credentialsHash,
+      ApplicationStatus status,
+      Currency currency,
+      uint8 precision,
+      bytes2 country,
+      bytes32 ledgerIdentifier,
+      bytes32[] assignedValidatorRoles,
+      uint256 validatorsReward,
+      uint256 galtSpaceReward
+    )
+  {
+    require(applications[_id].status != ApplicationStatus.NOT_EXISTS, "Application doesn't exist");
+
+    Application storage m = applications[_id];
+
+    return (
+      m.applicant,
+      m.packageTokenId,
+      m.credentialsHash,
+      m.status,
+      m.currency,
+      m.precision,
+      m.country,
+      m.ledgerIdentifier,
+      m.assignedRoles,
+      m.validatorsReward,
+      m.galtSpaceReward
+    );
+  }
+}

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -9,6 +9,7 @@ import "./SpaceToken.sol";
 import "./SplitMerge.sol";
 import "./Validators.sol";
 
+
 contract PlotClarificationManager is Initializable, Ownable {
   using SafeMath for uint256;
 
@@ -148,7 +149,7 @@ contract PlotClarificationManager is Initializable, Ownable {
     ERC20 _galtToken,
     address _galtSpaceRewardsAddress
   )
-    public
+    external
     isInitializer
   {
     owner = msg.sender;
@@ -168,30 +169,30 @@ contract PlotClarificationManager is Initializable, Ownable {
     paymentMethod = PaymentMethod.ETH_AND_GALT;
   }
 
-  function setGaltSpaceRewardsAddress(address _newAddress) public onlyOwner {
+  function setGaltSpaceRewardsAddress(address _newAddress) external onlyOwner {
     galtSpaceRewardsAddress = _newAddress;
   }
 
-  function setPaymentMethod(PaymentMethod _newMethod) public onlyOwner {
+  function setPaymentMethod(PaymentMethod _newMethod) external onlyOwner {
     paymentMethod = _newMethod;
   }
 
-  function setMinimalApplicationFeeInEth(uint256 _newFee) public onlyOwner {
+  function setMinimalApplicationFeeInEth(uint256 _newFee) external onlyOwner {
     minimalApplicationFeeInEth = _newFee;
   }
 
-  function setMinimalApplicationFeeInGalt(uint256 _newFee) public onlyOwner {
+  function setMinimalApplicationFeeInGalt(uint256 _newFee) external onlyOwner {
     minimalApplicationFeeInGalt = _newFee;
   }
 
-  function setGaltSpaceEthShare(uint256 _newShare) public onlyOwner {
+  function setGaltSpaceEthShare(uint256 _newShare) external onlyOwner {
     require(_newShare >= 1, "Percent value should be greater or equal to 1");
     require(_newShare <= 100, "Percent value should be greater or equal to 100");
 
     galtSpaceEthShare = _newShare;
   }
 
-  function setGaltSpaceGaltShare(uint256 _newShare) public onlyOwner {
+  function setGaltSpaceGaltShare(uint256 _newShare) external onlyOwner {
     require(_newShare >= 1, "Percent value should be greater or equal to 1");
     require(_newShare <= 100, "Percent value should be greater or equal to 100");
 
@@ -203,7 +204,7 @@ contract PlotClarificationManager is Initializable, Ownable {
     bytes32 _ledgerIdentifier,
     uint8 _precision
   )
-    public
+    external
     validatorsReady
     returns (bytes32)
   {
@@ -307,7 +308,7 @@ contract PlotClarificationManager is Initializable, Ownable {
     changeApplicationStatus(a, ApplicationStatus.SUBMITTED);
   }
 
-  function lockApplicationForReview(bytes32 _aId, bytes32 _role) public anyValidator {
+  function lockApplicationForReview(bytes32 _aId, bytes32 _role) external anyValidator {
     Application storage a = applications[_aId];
 
     require(validators.hasRole(msg.sender, _role), "Unable to lock with given roles");
@@ -325,7 +326,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   function approveApplication(
     bytes32 _aId
   )
-    public
+    external
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -357,7 +358,7 @@ contract PlotClarificationManager is Initializable, Ownable {
     bytes32 _aId,
     string _message
   )
-    public
+    external
     onlyValidatorOfApplication(_aId)
   {
     Application storage a = applications[_aId];
@@ -387,7 +388,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   function resubmitApplication(
     bytes32 _aId
   )
-    public
+    external
     onlyApplicant(_aId)
   {
     Application storage a = applications[_aId];
@@ -404,36 +405,6 @@ contract PlotClarificationManager is Initializable, Ownable {
     }
 
     changeApplicationStatus(a, ApplicationStatus.SUBMITTED);
-  }
-
-  function addGeohashesToApplication(
-    bytes32 _aId,
-    uint256[] _geohashes,
-    uint256[] _neighborsGeohashTokens,
-    bytes2[] _directions
-  )
-    public
-    onlyPusherRole
-  {
-    Application storage a = applications[_aId];
-
-    require(a.status == ApplicationStatus.APPROVED, "ApplicationStatus should be APPROVED");
-
-    for (uint8 i = 0; i < _geohashes.length; i++) {
-      uint256 geohashTokenId = spaceToken.geohashToTokenId(_geohashes[i]);
-      if (spaceToken.exists(geohashTokenId)) {
-        require(
-          spaceToken.ownerOf(geohashTokenId) == address(this),
-          "Existing geohash token should belongs to PlotClarificationManager contract"
-        );
-      } else {
-        spaceToken.mintGeohash(address(this), _geohashes[i]);
-      }
-
-      _geohashes[i] = geohashTokenId;
-    }
-
-    splitMerge.addGeohashesToPackage(a.packageTokenId, _geohashes, _neighborsGeohashTokens, _directions);
   }
 
   function applicationPackingCompleted(bytes32 _aId) external onlyPusherRole {
@@ -551,7 +522,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   function getApplicationById(
     bytes32 _id
   )
-    public
+    external
     view
     returns (
       ApplicationStatus status,
@@ -628,6 +599,36 @@ contract PlotClarificationManager is Initializable, Ownable {
     );
   }
 
+  function addGeohashesToApplication(
+    bytes32 _aId,
+    uint256[] _geohashes,
+    uint256[] _neighborsGeohashTokens,
+    bytes2[] _directions
+  )
+    public
+    onlyPusherRole
+  {
+    Application storage a = applications[_aId];
+
+    require(a.status == ApplicationStatus.APPROVED, "ApplicationStatus should be APPROVED");
+
+    for (uint8 i = 0; i < _geohashes.length; i++) {
+      uint256 geohashTokenId = spaceToken.geohashToTokenId(_geohashes[i]);
+      if (spaceToken.exists(geohashTokenId)) {
+        require(
+          spaceToken.ownerOf(geohashTokenId) == address(this),
+          "Existing geohash token should belongs to PlotClarificationManager contract"
+        );
+      } else {
+        spaceToken.mintGeohash(address(this), _geohashes[i]);
+      }
+
+      _geohashes[i] = geohashTokenId;
+    }
+
+    splitMerge.addGeohashesToPackage(a.packageTokenId, _geohashes, _neighborsGeohashTokens, _directions);
+  }
+
   function changeValidationStatus(
     Application storage _a,
     bytes32 _role,
@@ -699,5 +700,4 @@ contract PlotClarificationManager is Initializable, Ownable {
 
     assert(totalReward == a.validatorsReward);
   }
-
 }

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -108,7 +108,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   constructor () public {}
 
   modifier validatorsReady() {
-    // require(validators.isApplicationTypeReady(APPLICATION_TYPE), "Roles list not complete");
+     require(validators.isApplicationTypeReady(APPLICATION_TYPE), "Roles list not complete");
 
     _;
   }
@@ -277,6 +277,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   )
     external
     payable
+    validatorsReady
     onlyApplicant(_aId)
   {
     Application storage a = applications[_aId];

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -108,7 +108,7 @@ contract PlotClarificationManager is Initializable, Ownable {
   constructor () public {}
 
   modifier validatorsReady() {
-     require(validators.isApplicationTypeReady(APPLICATION_TYPE), "Roles list not complete");
+    require(validators.isApplicationTypeReady(APPLICATION_TYPE), "Roles list not complete");
 
     _;
   }

--- a/contracts/PlotClarificationManager.sol
+++ b/contracts/PlotClarificationManager.sol
@@ -407,6 +407,14 @@ contract PlotClarificationManager is Initializable, Ownable {
     splitMerge.addGeohashesToPackage(a.packageTokenId, _geohashes, _neighborsGeohashTokens, _directions);
   }
 
+  function applicationPackingCompleted(bytes32 _aId) external onlyPusherRole {
+    Application storage a = applications[_aId];
+
+    require(a.status == ApplicationStatus.APPROVED, "ApplicationStatus should be APPROVED");
+
+    a.status = ApplicationStatus.PACKED;
+  }
+
   function getApplicationById(
     bytes32 _id
   )

--- a/test/integration/testPlotClarificationManager.js
+++ b/test/integration/testPlotClarificationManager.js
@@ -9,13 +9,12 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const chaiBigNumber = require('chai-bignumber')(Web3.utils.BN);
 const galt = require('@galtproject/utils');
-const { ether, assertEqualBN, assertRevert, zeroAddress } = require('../helpers');
+const { ether, assertRevert, zeroAddress } = require('../helpers');
 
 const web3 = new Web3(PlotClarificationManager.web3.currentProvider);
 const { BN, utf8ToHex, hexToUtf8 } = Web3.utils;
 const NEW_APPLICATION = '0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6';
 const CLARIFICATION_APPLICATION = '0x6f7c49efa4ebd19424a5018830e177875fd96b20c1ae22bc5eb7be4ac691e7b7';
-const ANOTHER_APPLICATION = '0x2baf79c183ad5c683c3f4ffdffdd719a123a402f9474acde6ca3060ac1e46095';
 const PUSHER_ROLE = 'clarification pusher';
 
 // TODO: move to helpers
@@ -26,7 +25,6 @@ chai.use(chaiAsPromised);
 chai.use(chaiBigNumber);
 chai.should();
 
-const GEOHASH_MASK = new BN('0100000000000000000000000000000000000000000000000000000000000000', 16);
 const ApplicationStatus = {
   NOT_EXISTS: 0,
   NEW: 1,

--- a/test/integration/testPlotClarificationManager.js
+++ b/test/integration/testPlotClarificationManager.js
@@ -1,0 +1,117 @@
+const PlotClarificationManager = artifacts.require('./PlotClarificationManager.sol');
+const SpaceToken = artifacts.require('./SpaceToken.sol');
+const SplitMerge = artifacts.require('./SplitMerge.sol');
+const GaltToken = artifacts.require('./GaltToken.sol');
+const Validators = artifacts.require('./Validators.sol');
+const Web3 = require('web3');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const chaiBigNumber = require('chai-bignumber')(Web3.utils.BN);
+const galt = require('@galtproject/utils');
+const { ether, assertEqualBN, assertRevert, zeroAddress } = require('../helpers');
+
+const web3 = new Web3(PlotClarificationManager.web3.currentProvider);
+const { BN, utf8ToHex, hexToUtf8 } = Web3.utils;
+const NEW_APPLICATION = '0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6';
+const CLARIFICATION_APPLICATION = '0x6f7c49efa4ebd19424a5018830e177875fd96b20c1ae22bc5eb7be4ac691e7b7';
+const ANOTHER_APPLICATION = '0x2baf79c183ad5c683c3f4ffdffdd719a123a402f9474acde6ca3060ac1e46095';
+
+// TODO: move to helpers
+Web3.utils.BN.prototype.equal = Web3.utils.BN.prototype.eq;
+Web3.utils.BN.prototype.equals = Web3.utils.BN.prototype.eq;
+
+chai.use(chaiAsPromised);
+chai.use(chaiBigNumber);
+chai.should();
+
+const GEOHASH_MASK = new BN('0100000000000000000000000000000000000000000000000000000000000000', 16);
+const ApplicationStatus = {
+  NOT_EXISTS: 0,
+  NEW: 1,
+  SUBMITTED: 2,
+  APPROVED: 3,
+  REJECTED: 4,
+  REVERTED: 5,
+  DISASSEMBLED_BY_APPLICANT: 6,
+  DISASSEMBLED_BY_VALIDATOR: 7,
+  REVOKED: 8
+};
+
+const ValidationStatus = {
+  INTACT: 0,
+  LOCKED: 1,
+  APPROVED: 2,
+  REJECTED: 3,
+  REVERTED: 4
+};
+
+const PaymentMethods = {
+  NONE: 0,
+  ETH_ONLY: 1,
+  GALT_ONLY: 2,
+  ETH_AND_GALT: 3
+};
+
+const Currency = {
+  ETH: 0,
+  GALT: 1
+};
+
+Object.freeze(ApplicationStatus);
+Object.freeze(ValidationStatus);
+Object.freeze(PaymentMethods);
+Object.freeze(Currency);
+
+contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, alice, bob, charlie, dan, eve, frank]) => {
+  beforeEach(async function() {
+    this.initContour = ['qwerqwerqwer', 'ssdfssdfssdf', 'zxcvzxcvzxcv'];
+    this.initLedgerIdentifier = 'шц50023中222ائِيل';
+
+    this.contour = this.initContour.map(galt.geohashToNumber);
+    this.credentials = web3.utils.sha3(`Johnj$Galt$123456po`);
+    this.ledgerIdentifier = web3.utils.utf8ToHex(this.initLedgerIdentifier);
+
+    this.galtToken = await GaltToken.new({ from: coreTeam });
+    this.validators = await Validators.new({ from: coreTeam });
+    this.plotClarificationManager = await PlotClarificationManager.new({ from: coreTeam });
+    this.spaceToken = await SpaceToken.new('Space Token', 'SPACE', { from: coreTeam });
+    this.splitMerge = await SplitMerge.new({ from: coreTeam });
+
+    await this.spaceToken.initialize('SpaceToken', 'SPACE', { from: coreTeam });
+    await this.plotClarificationManager.initialize(
+      this.spaceToken.address,
+      this.splitMerge.address,
+      this.validators.address,
+      this.galtToken.address,
+      galtSpaceOrg,
+      {
+        from: coreTeam
+      }
+    );
+    await this.splitMerge.initialize(this.spaceToken.address, this.plotClarificationManager.address, {
+         from: coreTeam
+    });
+
+    await this.plotClarificationManager.setMinimalApplicationFeeInEth(ether(6));
+    await this.plotClarificationManager.setMinimalApplicationFeeInGalt(ether(45));
+    await this.plotClarificationManager.setGaltSpaceEthShare(33);
+    await this.plotClarificationManager.setGaltSpaceGaltShare(13);
+
+    await this.spaceToken.addRoleTo(this.plotClarificationManager.address, 'minter');
+    await this.spaceToken.addRoleTo(this.splitMerge.address, 'minter');
+    await this.spaceToken.addRoleTo(this.splitMerge.address, 'operator');
+
+    await this.galtToken.mint(alice, ether(10000), { from: coreTeam });
+
+    this.plotClarificationManagerWeb3 = new web3.eth.Contract(
+      this.plotClarificationManager.abi,
+      this.plotClarificationManager.address
+    );
+    this.spaceTokenWeb3 = new web3.eth.Contract(this.spaceToken.abi, this.spaceToken.address);
+    this.galtTokenWeb3 = new web3.eth.Contract(this.galtToken.abi, this.galtToken.address);
+  });
+
+  it.only('should be initialized successfully', async function() {
+    (await this.plotClarificationManager.minimalApplicationFeeInEth()).toString(10).should.be.a.bignumber.eq(ether(6));
+  });
+});

--- a/test/integration/testPlotClarificationManager.js
+++ b/test/integration/testPlotClarificationManager.js
@@ -809,5 +809,32 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, alice, bob, charl
         assert.equal(res.tokenWithdrawn, true);
       });
     });
+
+    describe('claim reward', () => {
+      beforeEach(async function() {
+        await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
+        await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
+        await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+          from: alice,
+          value: ether(6 + 7)
+        });
+        await this.plotClarificationManager.lockApplicationForReview(this.aId, 'human', { from: bob });
+        await this.plotClarificationManager.lockApplicationForReview(this.aId, 'dog', { from: eve });
+        await this.plotClarificationManager.approveApplication(this.aId, { from: bob });
+        await this.plotClarificationManager.approveApplication(this.aId, { from: dan });
+        await this.plotClarificationManager.approveApplication(this.aId, { from: eve });
+        await this.plotClarificationManager.applicationPackingCompleted(this.aId, { from: dan });
+        await this.plotClarificationManager.withdrawPackageToken(this.aId, { from: alice });
+      });
+
+      it('should change status tokenWithdrawn flag to true', async function() {
+        await this.plotClarificationManager.withdrawPackageToken(this.aId, { from: alice });
+
+        const res = await this.plotClarificationManagerWeb3.methods.getApplicationById(this.aId).call();
+        assert.equal(res.status, ApplicationStatus.PACKED);
+        assert.equal(res.tokenWithdrawn, true);
+      });
+    });
   });
 });

--- a/test/integration/testPlotClarificationManager.js
+++ b/test/integration/testPlotClarificationManager.js
@@ -111,7 +111,99 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, alice, bob, charl
     this.galtTokenWeb3 = new web3.eth.Contract(this.galtToken.abi, this.galtToken.address);
   });
 
-  it.only('should be initialized successfully', async function() {
+  it('should be initialized successfully', async function() {
     (await this.plotClarificationManager.minimalApplicationFeeInEth()).toString(10).should.be.a.bignumber.eq(ether(6));
+  });
+
+  describe.only('contract config modifiers', () => {
+    describe('#setGaltSpaceRewardsAddress()', () => {
+      it('should allow an owner set rewards address', async function() {
+        await this.plotClarificationManager.setGaltSpaceRewardsAddress(bob, { from: coreTeam });
+        // const res = await web3.eth.getStorageAt(this.plotClarificationManager.address, 5);
+        // assert.equal(res, bob);
+      });
+
+      it('should deny non-owner set rewards address', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceRewardsAddress(bob, { from: alice }));
+      });
+    });
+
+    describe('#setPaymentMethod()', () => {
+      it('should allow an owner set a payment method', async function() {
+        await this.plotClarificationManager.setPaymentMethod(PaymentMethods.ETH_ONLY, { from: coreTeam });
+        const res = await this.plotClarificationManager.paymentMethod();
+        assert.equal(res, PaymentMethods.ETH_ONLY);
+      });
+
+      it('should deny non-owner set a payment method', async function() {
+        await assertRevert(this.plotClarificationManager.setPaymentMethod(PaymentMethods.ETH_ONLY, { from: alice }));
+        const res = await this.plotClarificationManager.paymentMethod();
+        assert.equal(res, PaymentMethods.ETH_AND_GALT);
+      });
+    });
+
+    describe('#setApplicationFeeInEth()', () => {
+      it('should allow an owner set a new minimum fee in ETH', async function() {
+        await this.plotClarificationManager.setMinimalApplicationFeeInEth(ether(0.05), { from: coreTeam });
+        const res = await this.plotClarificationManager.minimalApplicationFeeInEth();
+        assert.equal(res, ether(0.05));
+      });
+
+      it('should deny any other than owner person set fee in ETH', async function() {
+        await assertRevert(this.plotClarificationManager.setMinimalApplicationFeeInEth(ether(0.05), { from: alice }));
+      });
+    });
+
+    describe('#setApplicationFeeInGalt()', () => {
+      it('should allow an owner set a new minimum fee in GALT', async function() {
+        await this.plotClarificationManager.setMinimalApplicationFeeInGalt(ether(0.15), { from: coreTeam });
+        const res = await this.plotClarificationManager.minimalApplicationFeeInGalt();
+        assert.equal(res, ether(0.15));
+      });
+
+      it('should deny any other than owner person set fee in GALT', async function() {
+        await assertRevert(this.plotClarificationManager.setMinimalApplicationFeeInGalt(ether(0.15), { from: alice }));
+      });
+    });
+
+    describe('#setGaltSpaceEthShare()', () => {
+      it('should allow an owner set galtSpace ETH share in percents', async function() {
+        await this.plotClarificationManager.setGaltSpaceEthShare('42', { from: coreTeam });
+        const res = await this.plotClarificationManager.galtSpaceEthShare();
+        assert.equal(res.toString(10), '42');
+      });
+
+      it('should deny owner set Galt Space EHT share less than 1 percent', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceEthShare('0.5', { from: coreTeam }));
+      });
+
+      it('should deny owner set Galt Space EHT share grater than 100 percents', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceEthShare('101', { from: coreTeam }));
+      });
+
+      it('should deny any other than owner set Galt Space EHT share in percents', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceEthShare('20', { from: alice }));
+      });
+    });
+
+    describe('#setGaltSpaceGaltShare()', () => {
+      it('should allow an owner set galtSpace Galt share in percents', async function() {
+        await this.plotClarificationManager.setGaltSpaceGaltShare('42', { from: coreTeam });
+        const res = await this.plotClarificationManager.galtSpaceGaltShare();
+        assert.equal(res.toString(10), '42');
+      });
+
+      it('should deny owner set Galt Space Galt share less than 1 percent', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceGaltShare('0.5', { from: coreTeam }));
+      });
+
+      it('should deny owner set Galt Space Galt share grater than 100 percents', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceGaltShare('101', { from: coreTeam }));
+      });
+
+      it('should deny any other than owner set Galt Space EHT share in percents', async function() {
+        await assertRevert(this.plotClarificationManager.setGaltSpaceGaltShare('20', { from: alice }));
+      });
+    });
   });
 });

--- a/test/integration/testPlotClarificationManager.js
+++ b/test/integration/testPlotClarificationManager.js
@@ -289,7 +289,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
       this.aId = res.logs[0].args.id;
     });
 
-    describe('#submitApplicationForReviewGalt()', () => {
+    describe('#submitApplicationForReview()', () => {
       beforeEach(async function() {
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
@@ -298,7 +298,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
 
       it('should allow an applicant pay commission and gas deposit in Galt', async function() {
         await this.galtToken.approve(this.plotClarificationManager.address, ether(45), { from: alice });
-        await this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(45), {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, ether(45), {
           from: alice,
           value: ether(7)
         });
@@ -313,7 +313,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         it('should reject applications without neither payment nor gas deposit', async function() {
           await this.galtToken.approve(this.plotClarificationManager.address, ether(45), { from: alice });
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, 0, {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
               from: alice
             })
           );
@@ -322,7 +322,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         it('should reject applications with gas deposit which less than required', async function() {
           await this.galtToken.approve(this.plotClarificationManager.address, ether(45), { from: alice });
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(45), {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, ether(45), {
               from: alice,
               value: ether(6)
             })
@@ -332,7 +332,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         it('should reject applications with payment which less than required', async function() {
           await this.galtToken.approve(this.plotClarificationManager.address, ether(45), { from: alice });
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(43), {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, ether(43), {
               from: alice,
               value: ether(7)
             })
@@ -342,7 +342,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         it('should reject applications with gas deposit greater than required', async function() {
           await this.galtToken.approve(this.plotClarificationManager.address, ether(47), { from: alice });
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(47), {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, ether(47), {
               from: alice,
               value: ether(8)
             })
@@ -351,7 +351,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
 
         it('should calculate corresponding validator and galtspace rewards', async function() {
           await this.galtToken.approve(this.plotClarificationManager.address, ether(47), { from: alice });
-          await this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(47), {
+          await this.plotClarificationManager.submitApplicationForReview(this.aId, ether(47), {
             from: alice,
             value: ether(7)
           });
@@ -367,7 +367,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         it('should calculate validator rewards according to their roles share', async function() {
           const { aId } = this;
           await this.galtToken.approve(this.plotClarificationManager.address, ether(47), { from: alice });
-          await this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(47), {
+          await this.plotClarificationManager.submitApplicationForReview(this.aId, ether(47), {
             from: alice,
             value: ether(7)
           });
@@ -398,7 +398,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
         await this.galtToken.approve(this.plotClarificationManager.address, ether(57), { from: alice });
-        await this.plotClarificationManager.submitApplicationForReviewGalt(this.aId, ether(57), {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, ether(57), {
           from: alice,
           value: ether(7)
         });
@@ -751,7 +751,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
       });
 
       it('should allow an applicant pay commission and gas deposit in ETH', async function() {
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -765,7 +765,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
       describe('payable', () => {
         it('should reject applications without payment', async function() {
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReview(this.aId, {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
               from: alice
             })
           );
@@ -773,21 +773,21 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
 
         it('should reject applications with payment which less than required', async function() {
           await assertRevert(
-            this.plotClarificationManager.submitApplicationForReview(this.aId, {
+            this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
               from: alice,
               value: 10
             })
           );
         });
         it('should allow pplications with payment greater than required', async function() {
-          await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+          await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
             from: alice,
             value: ether(23)
           });
         });
 
         it('should calculate corresponding validator and galtspace rewards', async function() {
-          await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+          await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
             from: alice,
             value: ether(14)
           });
@@ -801,7 +801,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
 
         it('should calculate validator rewards according to their roles share', async function() {
           const { aId } = this;
-          await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+          await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
             from: alice,
             value: ether(13)
           });
@@ -830,7 +830,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -881,7 +881,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -931,7 +931,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -999,7 +999,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -1046,7 +1046,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -1082,7 +1082,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -1115,7 +1115,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -1141,7 +1141,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });
@@ -1216,7 +1216,7 @@ contract('PlotClarificationManager', ([coreTeam, galtSpaceOrg, feeManager, alice
         await this.plotClarificationManager.submitApplicationForValuation(this.aId, { from: alice });
         await this.plotClarificationManager.lockApplicationForValuation(this.aId, { from: dan });
         await this.plotClarificationManager.valuateGasDeposit(this.aId, ether(7), { from: dan });
-        await this.plotClarificationManager.submitApplicationForReview(this.aId, {
+        await this.plotClarificationManager.submitApplicationForReview(this.aId, 0, {
           from: alice,
           value: ether(6 + 7)
         });

--- a/truffle.js
+++ b/truffle.js
@@ -22,7 +22,7 @@ const config = {
       provider: Ganache.provider({
         unlocked_accounts: [0, 1, 2, 3, 4, 5],
         vmErrorsOnRPCResponse: true,
-        default_balance_ether: 500,
+        default_balance_ether: 5000,
         // 7 800 000
         gasLimit: 0x7704c0
       }),


### PR DESCRIPTION
changes...

* f09548f PlotClarificationManager. Fix #validatorsReady() modifier
* 03c0795 PlotClarificationManager. Fix linter warnings
* 250c29b PlotClarificationManager. Combine submitForApplication ETH and GALT into a single method
* a5a99cd PlotClarificationManager. Add claim GALT reward methods
* aae9b5b PlotClarificationManager. Add claim ETH reward methods
* 3bcf4b4 PlotClarificationManager. Add #revertApplication(), #resubmitApplication(), #claimGasDepositAsValidator() and #claimGasDepositAsApplicant() methods
* ca5cb3f Increase default test balance to 5000 ETH
* 7a06c74 Add PlotClarificationManager.withdrawPackageToken method
* 97dd518 Add PlotClarificationManager.applicationPackingCompleted() method
* 41c96a6 Add PlotClarificationManager.addGeohashesToApplication
* b2f6a30 Add PlotClarificationManager.approveApplication()
* 83ce870 Add PlotClarificationManager.lockApplicationForReview() method
* f61f2b5 Add PlotClarificationManager.submitApplicationForReviewGalt() in GALT
* fdb1bbf Add PlotClarificationManager.submitApplicationForReview() - ETH method
* 4aa5306 Add PlotClarificationManager.valuateGas() method
* 74d6d46 Add PlotClarificationManager #submitApplicationForValudation() and #lockApplicationForValuation() methods
* 162530c Add PlotClarificationManager.applyForPlotClarification() method
* 009fa82 Add PlotClarificationManager contract modification tests
* 485880f Add a bare PlotClarificationManager contract with test